### PR TITLE
Add format method

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -1,0 +1,25 @@
+module.exports = function format (parsedUrl) {
+  var parts = ['protocol', 'domain', 'path', 'query', 'hash']
+  var url = ''
+  for (var i = 0; i < parts.length; i++) {
+    var part = parts[i]
+    if (parsedUrl.hasOwnProperty(part)) {
+      if (part === 'query') {
+        url += formatQuery(parsedUrl[part])
+      } else {
+        url += parsedUrl[part]
+      }
+    }
+  }
+  return url
+}
+
+function formatQuery (query) {
+  var parts = []
+  for (var param in query) {
+    if (query.hasOwnProperty(param)) {
+      parts.push(param + '=' + query[param])
+    }
+  }
+  return '?' + parts.join('&')
+}

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,5 +1,6 @@
 module.exports = function query (querystring) {
-  var obj = {}, i, keyValue
+  var i, keyValue
+  var obj = {}
   querystring = querystring.replace(/^\?/, '')
   if (!querystring) return {}
   var pairs = querystring.split('&')

--- a/test/format_test.js
+++ b/test/format_test.js
@@ -1,0 +1,14 @@
+/* global describe, it, expect */
+var parse = require('../lib/parse')
+var format = require('../lib/format')
+
+describe('format', function () {
+  it('should invert parse', function () {
+    expect(format(parse('http://www.bgark.com'))).to.eql('http://www.bgark.com')
+    expect(format(parse('http://www.bgark.com/path/s.jpg'))).to.eql('http://www.bgark.com/path/s.jpg')
+    expect(format(parse('http://www.bgark.com/path/s.jpg?mcgee=1&muggins=hello'))).to.eql('http://www.bgark.com/path/s.jpg?mcgee=1&muggins=hello')
+    expect(format(parse('http://www.bgark.com/path/s.jpg?mcgee=hello#hashtag'))).to.eql('http://www.bgark.com/path/s.jpg?mcgee=hello#hashtag')
+    expect(format(parse('http://www.bgark.com/subfolder/?mcgee=hello#hashtag'))).to.eql('http://www.bgark.com/subfolder/?mcgee=hello#hashtag')
+    expect(format(parse('www.bgark.com'))).to.eql('www.bgark.com')
+  })
+})


### PR DESCRIPTION
For use in portal, to avoid using node 'url' cutting off long cdn subdomains @alanclarke 
